### PR TITLE
Pen logic

### DIFF
--- a/scenes/characters/animal.tscn
+++ b/scenes/characters/animal.tscn
@@ -13,8 +13,9 @@ height = 1.0
 [sub_resource type="SphereShape3D" id="SphereShape3D_ah35l"]
 radius = 0.7
 
-[node name="Animal" type="CharacterBody3D"]
+[node name="Animal" type="CharacterBody3D" node_paths=PackedStringArray("desire")]
 script = ExtResource("1_4a3xr")
+desire = NodePath("Desire")
 
 [node name="Desire" type="Node" parent="." node_paths=PackedStringArray("animal_sprite")]
 script = ExtResource("5_88ntp")

--- a/scenes/characters/animal.tscn
+++ b/scenes/characters/animal.tscn
@@ -14,7 +14,6 @@ height = 1.0
 radius = 0.7
 
 [node name="Animal" type="CharacterBody3D"]
-motion_mode = 1
 script = ExtResource("1_4a3xr")
 
 [node name="Desire" type="Node" parent="." node_paths=PackedStringArray("animal_sprite")]

--- a/scenes/characters/animal.tscn
+++ b/scenes/characters/animal.tscn
@@ -6,7 +6,6 @@
 [ext_resource type="Script" path="res://scripts/characters/animal_sprite.gd" id="3_dlphk"]
 [ext_resource type="Script" path="res://scripts/mechanics/desire.gd" id="5_88ntp"]
 
-
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_wyftn"]
 radius = 0.3
 height = 1.0

--- a/scenes/characters/player.tscn
+++ b/scenes/characters/player.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://jmen0e87ma80"]
+[gd_scene load_steps=5 format=3 uid="uid://jmen0e87ma80"]
 
 [ext_resource type="Script" path="res://scripts/player/player.gd" id="1_g4b2t"]
 [ext_resource type="Texture2D" uid="uid://bpew4axhcdomu" path="res://assets/characters/simple_farmer.png" id="2_fyp6h"]
-[ext_resource type="PackedScene" uid="uid://cwmsx6nlgxkaa" path="res://scenes/mechanics/leash.tscn" id="2_xfrav"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_nea58"]
 radius = 0.3
@@ -15,7 +14,6 @@ radius = 4.0
 [node name="Player" type="CharacterBody3D"]
 motion_mode = 1
 script = ExtResource("1_g4b2t")
-leash_packed_scene = ExtResource("2_xfrav")
 
 [node name="CollisionShape2D" type="CollisionShape3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)

--- a/scenes/levels/test_levels/alex_test_level.tscn
+++ b/scenes/levels/test_levels/alex_test_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://c3alwvlu7bmqq"]
+[gd_scene load_steps=16 format=3 uid="uid://c3alwvlu7bmqq"]
 
 [ext_resource type="PackedScene" uid="uid://jmen0e87ma80" path="res://scenes/characters/player.tscn" id="1_uer05"]
 [ext_resource type="Texture2D" uid="uid://bqnfiiqshhhha" path="res://assets/scenery/grass_tile.png" id="1_yopsd"]
@@ -25,7 +25,20 @@ albedo_texture = ExtResource("1_yopsd")
 uv1_triplanar = true
 texture_filter = 0
 
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_il7ka"]
+albedo_color = Color(1, 0, 0, 1)
+
 [sub_resource type="BoxShape3D" id="BoxShape3D_gfj3e"]
+size = Vector3(4, 1, 4)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_2gkno"]
+albedo_color = Color(0.0333333, 0, 1, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_t038i"]
+albedo_color = Color(0.0166667, 1, 0, 1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_m4dnu"]
+albedo_color = Color(0.983333, 1, 0, 1)
 
 [node name="AlexTestLevel" type="Node"]
 
@@ -50,7 +63,7 @@ metadata/_edit_lock_ = true
 lasso_range = 0.7
 
 [node name="Camera3D" type="Camera3D" parent="Level/Player"]
-transform = Transform3D(1, 0, 0, 0, 0.766044, 0.642788, 0, -0.642788, 0.766044, 0, 5, 5.3)
+transform = Transform3D(1, 0, 0, 0, 0.766044, 0.642788, 0, -0.642788, 0.766044, 0, 6.645, 7.64)
 fov = 45.0
 size = 2.709
 
@@ -72,13 +85,52 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.25795, 4.76837e-07, 3.91713
 [node name="Animal3" parent="Level" instance=ExtResource("4_wejr3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.29569, 4.76837e-07, -5.58656)
 
-[node name="CSGBox3D" type="CSGBox3D" parent="Level"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.88929, 0, 4.52151)
+[node name="RedPen" type="CSGBox3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.35889, 0.025, 8.92349)
+size = Vector3(4, 0.05, 4)
+material = SubResource("StandardMaterial3D_il7ka")
 
-[node name="PenArea" type="Area3D" parent="Level/CSGBox3D"]
+[node name="PenArea" type="Area3D" parent="Level/RedPen"]
 script = ExtResource("4_j4edg")
+desire_type = 1
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="Level/CSGBox3D/PenArea"]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Level/RedPen/PenArea"]
+shape = SubResource("BoxShape3D_gfj3e")
+
+[node name="BluePen" type="CSGBox3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 9.3205, 0.025, 9.06598)
+size = Vector3(4, 0.05, 4)
+material = SubResource("StandardMaterial3D_2gkno")
+
+[node name="PenArea" type="Area3D" parent="Level/BluePen"]
+script = ExtResource("4_j4edg")
+desire_type = 2
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Level/BluePen/PenArea"]
+shape = SubResource("BoxShape3D_gfj3e")
+
+[node name="GreenPen" type="CSGBox3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -8.53789, 0.025, -6.03453)
+size = Vector3(4, 0.05, 4)
+material = SubResource("StandardMaterial3D_t038i")
+
+[node name="PenArea" type="Area3D" parent="Level/GreenPen"]
+script = ExtResource("4_j4edg")
+desire_type = 3
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Level/GreenPen/PenArea"]
+shape = SubResource("BoxShape3D_gfj3e")
+
+[node name="YellowPen" type="CSGBox3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 8.89017, 0.025, -5.46226)
+size = Vector3(4, 0.05, 4)
+material = SubResource("StandardMaterial3D_m4dnu")
+
+[node name="PenArea" type="Area3D" parent="Level/YellowPen"]
+script = ExtResource("4_j4edg")
+desire_type = 4
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Level/YellowPen/PenArea"]
 shape = SubResource("BoxShape3D_gfj3e")
 
 [node name="HUD" type="Control" parent="."]

--- a/scenes/levels/test_levels/alex_test_level.tscn
+++ b/scenes/levels/test_levels/alex_test_level.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=9 format=3 uid="uid://c3alwvlu7bmqq"]
+[gd_scene load_steps=11 format=3 uid="uid://c3alwvlu7bmqq"]
 
 [ext_resource type="PackedScene" uid="uid://jmen0e87ma80" path="res://scenes/characters/player.tscn" id="1_uer05"]
 [ext_resource type="Texture2D" uid="uid://bqnfiiqshhhha" path="res://assets/scenery/grass_tile.png" id="1_yopsd"]
 [ext_resource type="PackedScene" uid="uid://ce8i21qt6ws87" path="res://scenes/ui/shout_bar.tscn" id="3_kng4s"]
+[ext_resource type="Script" path="res://scripts/mechanics/pen.gd" id="4_j4edg"]
 [ext_resource type="PackedScene" uid="uid://d2m7e7f1ij6ss" path="res://scenes/characters/animal.tscn" id="4_wejr3"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_1d0ar"]
@@ -22,6 +23,8 @@ glow_enabled = true
 albedo_texture = ExtResource("1_yopsd")
 uv1_triplanar = true
 texture_filter = 0
+
+[sub_resource type="BoxShape3D" id="BoxShape3D_gfj3e"]
 
 [node name="AlexTestLevel" type="Node"]
 
@@ -67,6 +70,15 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.25795, 4.76837e-07, 3.91713
 
 [node name="Animal3" parent="Level" instance=ExtResource("4_wejr3")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.29569, 4.76837e-07, -5.58656)
+
+[node name="CSGBox3D" type="CSGBox3D" parent="Level"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4.88929, 0, 4.52151)
+
+[node name="PenArea" type="Area3D" parent="Level/CSGBox3D"]
+script = ExtResource("4_j4edg")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="Level/CSGBox3D/PenArea"]
+shape = SubResource("BoxShape3D_gfj3e")
 
 [node name="HUD" type="Control" parent="."]
 layout_mode = 3

--- a/scenes/levels/test_levels/alex_test_level.tscn
+++ b/scenes/levels/test_levels/alex_test_level.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=11 format=3 uid="uid://c3alwvlu7bmqq"]
+[gd_scene load_steps=12 format=3 uid="uid://c3alwvlu7bmqq"]
 
 [ext_resource type="PackedScene" uid="uid://jmen0e87ma80" path="res://scenes/characters/player.tscn" id="1_uer05"]
 [ext_resource type="Texture2D" uid="uid://bqnfiiqshhhha" path="res://assets/scenery/grass_tile.png" id="1_yopsd"]
 [ext_resource type="PackedScene" uid="uid://ce8i21qt6ws87" path="res://scenes/ui/shout_bar.tscn" id="3_kng4s"]
 [ext_resource type="Script" path="res://scripts/mechanics/pen.gd" id="4_j4edg"]
 [ext_resource type="PackedScene" uid="uid://d2m7e7f1ij6ss" path="res://scenes/characters/animal.tscn" id="4_wejr3"]
+[ext_resource type="PackedScene" uid="uid://cru7nkq8vmpey" path="res://scenes/systems/storm_system.tscn" id="6_nc3aw"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_1d0ar"]
 sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
@@ -103,3 +104,8 @@ offset_left = 953.0
 offset_top = 534.0
 offset_right = 953.0
 offset_bottom = 534.0
+
+[node name="Systems" type="Node" parent="."]
+
+[node name="StormSystem" parent="Systems" instance=ExtResource("6_nc3aw")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.991115, 0)

--- a/scenes/mechanics/leash.tscn
+++ b/scenes/mechanics/leash.tscn
@@ -3,7 +3,6 @@
 [ext_resource type="Script" path="res://scripts/mechanics/leash.gd" id="1_3ocpm"]
 [ext_resource type="Texture2D" uid="uid://bid43j03uy7nc" path="res://assets/scenery/wood_tile.png" id="2_axy5l"]
 
-
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_wx3ut"]
 shading_mode = 0
 albedo_texture = ExtResource("2_axy5l")
@@ -23,6 +22,7 @@ cap_bottom = false
 [node name="Leash" type="Node3D"]
 script = ExtResource("1_3ocpm")
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+[node name="Mesh" type="MeshInstance3D" parent="."]
+unique_name_in_owner = true
 transform = Transform3D(1.91069e-15, -4.37114e-08, -1, -1, -4.37114e-08, 0, -4.37114e-08, 1, -4.37114e-08, 0, 0, -0.5)
 mesh = SubResource("CylinderMesh_2t2si")

--- a/scenes/mechanics/pen.tscn
+++ b/scenes/mechanics/pen.tscn
@@ -1,7 +1,6 @@
-[gd_scene format=3 uid="uid://d1e1gu4wfx840"]
+[gd_scene load_steps=2 format=3 uid="uid://d3frlqkb0np11"]
 
-[node name="Pen" type="Node2D"]
+[ext_resource type="Script" path="res://scripts/mechanics/pen.gd" id="1_nbjw6"]
 
-[node name="TextureRect" type="TextureRect" parent="."]
-offset_right = 40.0
-offset_bottom = 40.0
+[node name="PenArea" type="Area3D"]
+script = ExtResource("1_nbjw6")

--- a/scripts/characters/animal.gd
+++ b/scripts/characters/animal.gd
@@ -1,12 +1,14 @@
 extends CharacterBody3D
 class_name Animal
 
+@export var desire: Desire
 @export var wander_speed: float = 0.5
 @export var scared_speed: float = 1.0
 @export var scared_duration: float = 3.0 ## How long the animal will be scared for
 
 @onready var lasso_icon: Sprite3D = %LassoIcon
 @onready var leash_point: Node3D = %LeashPoint
+
 
 var wander_vector: Vector2 = Vector2.DOWN
 

--- a/scripts/characters/animal.gd
+++ b/scripts/characters/animal.gd
@@ -8,8 +8,6 @@ class_name Animal
 @onready var lasso_icon: Sprite3D = %LassoIcon
 @onready var leash_point: Node3D = %LeashPoint
 
-var leash: Leash = null
-
 var wander_vector: Vector2 = Vector2.DOWN
 
 enum State {

--- a/scripts/characters/animal.gd
+++ b/scripts/characters/animal.gd
@@ -42,9 +42,10 @@ func _physics_process(delta):
 			var sign = ((randi() % 2) - 0.5) * 2
 			wander_vector = wander_vector.rotated(sign * delta * 3)
 			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * wander_speed
-			move_and_slide()
 		State.SCARED:
 			var sign = ((randi() % 2) - 0.5) * 2
 			wander_vector = wander_vector.rotated(sign * delta * 3)
 			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * scared_speed
-			move_and_slide()
+	if not is_on_floor():
+		velocity += get_gravity()
+	move_and_slide()

--- a/scripts/mechanics/desire.gd
+++ b/scripts/mechanics/desire.gd
@@ -6,13 +6,16 @@ class_name Desire
 ## and those that are 'storm-specific' for the time-being.
 enum DesireType {
 	NONE,
-	THIRSTY,
-	INJURED,
-	HUNGRY,
-	WET,
-	SHOCKED,
-	BURNING,
-	MAX,
+	RED_PEN,
+	BLUE_PEN,
+	GREEN_PEN,
+	YELLOW_PEN,
+	#THIRSTY,
+	#INJURED,
+	#HUNGRY,
+	#WET,
+	#SHOCKED,
+	#BURNING,
 }
 
 ## The animal sprite being updated with desire colors.
@@ -24,12 +27,16 @@ enum DesireType {
 ## (╯°□°)╯︵ ┻━┻
 @export var desire_to_color_map: Dictionary = {
 	DesireType.NONE: Color.WHITE,
-	DesireType.THIRSTY: Color.GREEN,
-	DesireType.INJURED: Color.PINK,
-	DesireType.HUNGRY: Color.SADDLE_BROWN,
-	DesireType.WET: Color.BLUE,
-	DesireType.SHOCKED: Color.YELLOW,
-	DesireType.BURNING: Color.FIREBRICK,
+	DesireType.RED_PEN: Color.RED,
+	DesireType.BLUE_PEN: Color.BLUE,
+	DesireType.GREEN_PEN: Color.GREEN,
+	DesireType.YELLOW_PEN: Color.YELLOW,
+	#DesireType.THIRSTY: Color.GREEN,
+	#DesireType.INJURED: Color.PINK,
+	#DesireType.HUNGRY: Color.SADDLE_BROWN,
+	#DesireType.WET: Color.BLUE,
+	#DesireType.SHOCKED: Color.YELLOW,
+	#DesireType.BURNING: Color.FIREBRICK,
 }
 
 ## String representation for the current desire.
@@ -49,7 +56,7 @@ func roll_new_desire_and_update_sprite() -> void:
 		return
 
 	var rng = RandomNumberGenerator.new()
-	var random_desire_type = rng.randi_range(0, DesireType.MAX - 1) as DesireType
+	var random_desire_type: DesireType = DesireType.values().pick_random() #rng.randi_range(0, DesireType.MAX - 1) as DesireType
 	if not desire_to_color_map.has(random_desire_type):
 		print_debug("Attempted to set a desire ", DesireType.keys()[random_desire_type], " but it doesn't have a valid color set")
 		return

--- a/scripts/mechanics/leash.gd
+++ b/scripts/mechanics/leash.gd
@@ -1,9 +1,75 @@
 extends Node3D
 class_name Leash
 
-@export var end_node: Node3D
+static var leash_packed_scene: PackedScene = preload("res://scenes/mechanics/leash.tscn")
+
+static var all_leashes: Array[Leash] = []
+static var leashed_characters: Array[CharacterBody3D]
+
+static var unleashed_signal: Signal = Signal()
+
+## Anchor is the node that pulls the leashee.
+static func create_leash(anchor: Node3D, leashee: Node3D) -> Leash:
+	var leash: Leash = leash_packed_scene.instantiate()
+	anchor.add_child(leash)
+	leash.end_node = leashee
+	return leash
+
+## Removes all leashes that are pulling on a character.
+static func unleash(character: CharacterBody3D) -> void:
+	for leash in all_leashes:
+		if leash.leashed_character == character:
+			leash.queue_free()
+			all_leashes.erase(leash)
+
+## The minimum distance a character needs to be from the leash origin for it to be dragged.
+@export var min_drag_distance: float = 1
+@export var pull_coefficient: float = 0.7
+
+## The node to connect to. It's owner will be dragged if it is a CharacterBody3D.
+@export var end_node: Node3D:
+	set(value):
+		if leashed_character:
+			leashed_characters.erase(leashed_character)
+			leashed_character.tree_exited.disconnect(_on_leashed_character_exiting_tree)
+		if value and value.owner is CharacterBody3D:
+			leashed_character = value.owner
+			leashed_character.tree_exiting.connect(_on_leashed_character_exiting_tree)
+			leashed_characters.append(leashed_character)
+		else:
+			leashed_character = null
+		end_node = value
+
+var leashed_character: CharacterBody3D = null
+
+func _on_leashed_character_exiting_tree() -> void:
+	queue_free()
+
+func _enter_tree():
+	all_leashes.append(self)
+
+func _exit_tree():
+	all_leashes.erase(self)
+	if leashed_character:
+		var unleash_character = true
+		for leash in all_leashes:
+			if leash.leashed_character == leashed_character:
+				unleash_character = false
+		if unleash_character:
+			leashed_characters.erase(leashed_character)
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(_delta):
 	look_at(end_node.global_position)
 	scale.z = global_position.distance_to(end_node.global_position)
+	if leashed_character and global_position.distance_to(leashed_character.global_position) > min_drag_distance:
+		leashed_character.velocity = (global_position - leashed_character.global_position) * pull_coefficient
+		leashed_character.move_and_slide()
+
+## Makes the leash invisible.
+func make_invisible() -> void:
+	%Mesh.visible = false
+
+## Makes the leash visible.
+func make_visible() -> void:
+	%Mesh.visible = true

--- a/scripts/mechanics/pen.gd
+++ b/scripts/mechanics/pen.gd
@@ -1,10 +1,13 @@
 extends Area3D
 class_name PenArea
 
+static var penned_signal: Signal = Signal()
+
 ## Invisible Leash settings
 @export var min_drag_distance: float = 2
 ## Invisible Leash settings
 @export var pull_coefficient: float = 0.2
+@export var desire_type: Desire.DesireType = Desire.DesireType.NONE
 
 var penned_animals: Array[Animal] = []
 
@@ -15,10 +18,14 @@ func _ready():
 	body_entered.connect(func(body: Node3D):
 		if body is Animal and body not in penned_animals:
 			var animal: Animal = body
+			if animal.desire.current_desire != desire_type:
+				return
 			penned_animals.append(animal)
 			Leash.unleash(animal)
 			var leash = Leash.create_leash(self, animal.leash_point)
 			leash.min_drag_distance = min_drag_distance
 			leash.pull_coefficient = pull_coefficient
 			leash.make_invisible()
+			PenArea.penned_signal.emit()
+			print("Animal penned")
 	)

--- a/scripts/mechanics/pen.gd
+++ b/scripts/mechanics/pen.gd
@@ -1,0 +1,24 @@
+extends Area3D
+class_name PenArea
+
+## Invisible Leash settings
+@export var min_drag_distance: float = 2
+## Invisible Leash settings
+@export var pull_coefficient: float = 0.2
+
+var penned_animals: Array[Animal] = []
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	## When an animal touched the pen area, remove any leashes,
+	## and attach an invisible leash to keep them inside the pen.
+	body_entered.connect(func(body: Node3D):
+		if body is Animal and body not in penned_animals:
+			var animal: Animal = body
+			penned_animals.append(animal)
+			Leash.unleash(animal)
+			var leash = Leash.create_leash(self, animal.leash_point)
+			leash.min_drag_distance = min_drag_distance
+			leash.pull_coefficient = pull_coefficient
+			leash.make_invisible()
+	)

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -1,15 +1,12 @@
 class_name PlayerController
 extends CharacterBody3D
 
-@export var leash_packed_scene: PackedScene = null
-
 @export var shout_cooldown: float = 5 # Seconds
 @export var speed: float = 4
 ## The player's speed is multiplied by this number to the power of the number of leashed_animals.
 ## This lets the player can leash as many animals as they want without completely stopping.
 @export_range(0, 1) var speed_reduction_per_dragged_body: float = 0.85
-## The minimum distance an animal needs to be from the player for it to be dragged while being leashed.
-@export var min_drag_distance: float = 1
+
 @export var lasso_range: float = 3
 
 @onready var raycast: RayCast3D = %RayCast3D
@@ -25,7 +22,6 @@ var targeted_animal: Animal:
 		if targeted_animal:
 			targeted_animal.show_lasso()
 
-var leashed_animals: Array[Animal] = []
 var current_shout_cooldown: float = 0
 
 func _ready() -> void:
@@ -42,25 +38,16 @@ func _physics_process(_delta: float) -> void:
 	
 	# Handle targetting and leashing of animals
 	var body: Area3D = raycast.get_collider()
-	if body and body.owner is Animal and body.owner not in leashed_animals:
+	if body and body.owner is Animal and body.owner not in Leash.leashed_characters:
 		targeted_animal = body.owner
 		if Input.is_action_just_pressed("use_lasso"):
-			leashed_animals.append(body.owner)
-			var leash: Leash = leash_packed_scene.instantiate()
-			leash_point.add_child(leash)
-			leash.end_node = body.owner.leash_point
+			Leash.create_leash(leash_point, targeted_animal.leash_point)
 	else:
 		targeted_animal = null
 		
-	var movement_vector: Vector2 = direction * (speed * pow(speed_reduction_per_dragged_body, leashed_animals.size()))
+	var movement_vector: Vector2 = direction * (speed * pow(speed_reduction_per_dragged_body, Leash.leashed_characters.size()))
 	velocity = Vector3(movement_vector.x, 0, movement_vector.y)
 	move_and_slide()
-	
-	# Drag leashed animals
-	for animal: Animal in leashed_animals:
-		if global_position.distance_to(animal.global_position) > min_drag_distance:
-			animal.velocity = (global_position - animal.global_position) * 0.7
-			animal.move_and_slide()
 
 func _process(delta: float):
 	current_shout_cooldown += delta

--- a/scripts/player/player.gd
+++ b/scripts/player/player.gd
@@ -22,6 +22,7 @@ var targeted_animal: Animal:
 		if targeted_animal:
 			targeted_animal.show_lasso()
 
+var dragged_animal_count: int = 0
 var current_shout_cooldown: float = 0
 
 func _ready() -> void:
@@ -41,11 +42,15 @@ func _physics_process(_delta: float) -> void:
 	if body and body.owner is Animal and body.owner not in Leash.leashed_characters:
 		targeted_animal = body.owner
 		if Input.is_action_just_pressed("use_lasso"):
-			Leash.create_leash(leash_point, targeted_animal.leash_point)
+			var leash: Leash = Leash.create_leash(leash_point, targeted_animal.leash_point)
+			dragged_animal_count += 1
+			leash.tree_exiting.connect(func():
+				dragged_animal_count -= 1
+			)
 	else:
 		targeted_animal = null
 		
-	var movement_vector: Vector2 = direction * (speed * pow(speed_reduction_per_dragged_body, Leash.leashed_characters.size()))
+	var movement_vector: Vector2 = direction * (speed * pow(speed_reduction_per_dragged_body, dragged_animal_count))
 	velocity = Vector3(movement_vector.x, 0, movement_vector.y)
 	move_and_slide()
 


### PR DESCRIPTION
- Moved all core leashing logic to Leash.
- Created PenArea node which inherits from Area3D. This node is used to create the hitbox for a pen and set it's DesireType. When an animal of a matching DesireType goes into the PenArea, it's leashes will be removed and it will be binded to the PenArea with an invisible Leash.
- Put everything together in alex_test_level with 4 different types of pens.
- PenArea has a static signal that can be listened to which emits whenever an animal has been penned.