### PR TITLE
Animal Physics Optimizations + Level Collision Fixes

### DIFF
--- a/assets/scenery/game_boundary.tscn
+++ b/assets/scenery/game_boundary.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://d4gk5su0q58i5"]
+[gd_scene load_steps=6 format=3 uid="uid://d4gk5su0q58i5"]
 
 [ext_resource type="Texture2D" uid="uid://bux870uvh64bl" path="res://assets/scenery/Trees/tile_0005.png" id="1_3pss5"]
 
@@ -8,8 +8,11 @@ size = Vector3(13, 5, 70)
 [sub_resource type="BoxShape3D" id="BoxShape3D_8we0y"]
 size = Vector3(13, 5, 70)
 
+[sub_resource type="BoxShape3D" id="BoxShape3D_qc2ye"]
+size = Vector3(30, 5, 10.0493)
+
 [sub_resource type="BoxShape3D" id="BoxShape3D_67ajv"]
-size = Vector3(30, 5, 15)
+size = Vector3(30, 5, 5.70435)
 
 [node name="Boundary" type="StaticBody3D"]
 
@@ -4889,5 +4892,9 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 20.4754, 1, 0)
 shape = SubResource("BoxShape3D_8we0y")
 
 [node name="Top" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -27.1526)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -24.9801)
+shape = SubResource("BoxShape3D_qc2ye")
+
+[node name="Bottom" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 26.178)
 shape = SubResource("BoxShape3D_67ajv")

--- a/scenes/characters/animal.tscn
+++ b/scenes/characters/animal.tscn
@@ -11,9 +11,8 @@
 [ext_resource type="AudioStream" uid="uid://dbwhw0fntviay" path="res://assets/audio/sfx/cow/scream 3.wav" id="10_vsup7"]
 [ext_resource type="AudioStream" uid="uid://d2m2enwggvcgy" path="res://assets/audio/sfx/cow/scream 10.wav" id="11_b1qao"]
 
-[sub_resource type="CapsuleShape3D" id="CapsuleShape3D_wyftn"]
-radius = 0.3
-height = 1.0
+[sub_resource type="BoxShape3D" id="BoxShape3D_c8mug"]
+size = Vector3(1, 0.9, 0.8)
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_76grc"]
 resource_local_to_scene = true
@@ -96,8 +95,8 @@ script = ExtResource("1_4a3xr")
 desire = NodePath("Desire")
 
 [node name="CollisionShape3D" type="CollisionShape3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.5, 0)
-shape = SubResource("CapsuleShape3D_wyftn")
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.45, -2.98023e-08)
+shape = SubResource("BoxShape3D_c8mug")
 
 [node name="Tilt" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0)
@@ -152,7 +151,6 @@ volume_db = -20.0
 pitch_scale = 0.2
 
 [node name="Timer" type="Timer" parent="."]
-process_callback = 0
 wait_time = 2.0
 autostart = true
 

--- a/scenes/characters/animal.tscn
+++ b/scenes/characters/animal.tscn
@@ -151,4 +151,10 @@ stream = SubResource("AudioStreamRandomizer_xel7d")
 volume_db = -20.0
 pitch_scale = 0.2
 
+[node name="Timer" type="Timer" parent="."]
+process_callback = 0
+wait_time = 2.0
+autostart = true
+
 [connection signal="timeout" from="Tilt/AnimatedSprite3D/Moodlet/MoodletUpdateTimer" to="Tilt/AnimatedSprite3D/Moodlet" method="_on_timer_timeout"]
+[connection signal="timeout" from="Timer" to="." method="change_wander_vector"]

--- a/scenes/levels/test_levels/alex_test_level.tscn
+++ b/scenes/levels/test_levels/alex_test_level.tscn
@@ -175,9 +175,9 @@ material = SubResource("StandardMaterial3D_ge7ww")
 metadata/_edit_lock_ = true
 
 [node name="InvisFloor" type="CSGBox3D" parent="MoLevel"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.109828, 0.161096, -0.0772705)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.109828, 0.161096, 2.29783)
 use_collision = true
-size = Vector3(30, 1.2, 42.4)
+size = Vector3(30, 1.2, 47.1502)
 material = SubResource("StandardMaterial3D_o0fwe")
 
 [node name="LevelEnvironment" type="Node3D" parent="MoLevel"]

--- a/scripts/characters/animal.gd
+++ b/scripts/characters/animal.gd
@@ -58,12 +58,11 @@ func _physics_process(delta: float) -> void:
 		State.THROWN:
 			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * throw_intensity
 	
-	if not is_on_floor():
-		velocity += get_gravity()
-	
 	if is_on_floor() and is_thrown:
 		is_thrown = false
 		state = State.WANDERING
+	elif not is_on_floor():
+		velocity += get_gravity()
 	
 	move_and_slide()
 

--- a/scripts/characters/animal.gd
+++ b/scripts/characters/animal.gd
@@ -49,20 +49,14 @@ func throw(throwing_position: Vector3) -> void:
 	state = State.THROWN
 	is_thrown = true
 	
-func _physics_process(delta):
+func _physics_process(delta: float) -> void:
 	match state:
 		State.WANDERING:
-			var _sign = ((randi() % 2) - 0.5) * 2
-			wander_vector = wander_vector.rotated(_sign * delta * 3)
 			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * wander_speed
 		State.SCARED:
-			var _sign = ((randi() % 2) - 0.5) * 2
-			wander_vector = wander_vector.rotated(_sign * delta * 3)
 			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * scared_speed
 		State.THROWN:
-			var _sign = ((randi() % 2) - 0.5) * 2
-			wander_vector = wander_vector.rotated(_sign * delta * 3)
-			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * (_sign * throw_intensity)
+			velocity = Vector3(wander_vector.x, 0, wander_vector.y).normalized() * throw_intensity
 	
 	if not is_on_floor():
 		velocity += get_gravity()
@@ -72,3 +66,6 @@ func _physics_process(delta):
 		state = State.WANDERING
 	
 	move_and_slide()
+
+func change_wander_vector() -> void:
+	wander_vector = wander_vector.rotated((randf() - 0.5) * PI)


### PR DESCRIPTION
- Fixed level boundary collision at the bottom of the level and floor collision not extending far enough at the bottom of the level.
- Optimized Animal:
  - Animal wander vector now only changes every two seconds instead of every physics tick.
  - Optimized Animal._physics_process
  - Animal collision shape changed from Capsule shape to Box shape.
    - (This caused a side effect where Shouting feels more useful now).

On my system, these optimizations allow ~30% more animals to spawn before the framerate begins to dip below 60fps.
This project's performance is bottlenecked by physics processing.